### PR TITLE
Add alt-text for images in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
   <div class="parallax-container">
     <div class="parallax"><img src="https://images.unsplash.com/photo-1466656528034-6b43e26d9834?dpr=2&auto=format&fit=crop&w=1080&h=268&q=80&cs=tinysrgb&crop="
-        alt="picture" /></div>
+        alt="Background picture showing a view of Vienna" /></div>
   </div>
 
   <div class="section teal">
@@ -41,7 +41,7 @@
       <h5>The official local group of</h5>
       <h3><a href="https://www.freecodecamp.org/" class="teal-text text-darken-4">FreeCodeCamp</a></h3>
       <h5>in Vienna, Austria</h5>
-      <img src="./images/AustriaFlag.svg" alt="picture" height=100em />
+      <img src="./images/AustriaFlag.svg" alt="Flag of Austria" height=100em />
     </div>
   </div>
 
@@ -81,7 +81,7 @@
 
 
   <div class="parallax-container">
-    <div class="parallax"><img src="https://secure.meetupstatic.com/photos/event/6/d/e/d/highres_462628141.jpeg" alt="picture" /></div>
+    <div class="parallax"><img src="https://secure.meetupstatic.com/photos/event/6/d/e/d/highres_462628141.jpeg" alt="Background picture showing FreeCodeCampers at a meetup" /></div>
   </div>
 
   <div class="section teal">
@@ -151,7 +151,7 @@
 
   <div class="parallax-container">
     <div class="parallax"><img src="https://images.unsplash.com/photo-1456746263245-1d5a803ee466?dpr=2&auto=format&fit=crop&w=1080&h=291&q=80&cs=tinysrgb&crop="
-        alt="picture" /></div>
+        alt="Background picture showing skyscrapers in Vienna" /></div>
   </div>
 
 
@@ -168,7 +168,7 @@
               <div class="row valign-wrapper">
                 <div class="col s2">
                   <a href="http://www.createdd.com/">
-                  <img src="https://avatars3.githubusercontent.com/u/22077628?v=3&s=460" alt="" class="circle responsive-img">
+                  <img src="https://avatars3.githubusercontent.com/u/22077628?v=3&s=460" alt="Avatar of Daniel Deutsch" class="circle responsive-img">
                 </a>
                 </div>
                 <div class="col s10">
@@ -182,7 +182,7 @@
               <div class="row valign-wrapper">
                 <div class="col s2">
                   <a href="http://rob.ee/">
-                  <img src="https://avatars3.githubusercontent.com/u/13132899?v=3&s=460" alt="" class="circle responsive-img">
+                  <img src="https://avatars3.githubusercontent.com/u/13132899?v=3&s=460" alt="Avatar of Robert Axelsen" class="circle responsive-img">
                 </a>
                 </div>
                 <div class="col s10">


### PR DESCRIPTION
Adding a meaningful alternative-text for images.

This is especially useful for visually impaired people (generally all using screen readers), but also relevant for search engines.
(Further reading: http://webaim.org/techniques/alttext/)

Feel free to improve the texts