### PR TITLE
adds the 101 logo to the partners and friends section, closes issue #37

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
   <div class="container row">
     <ul class="normalize-ul">
       <li>
-      <div class="col s12 m3 offset-m3">
+      <div class="col s12 m4">
         <a class="partner-logo" href="http://www.webclerks.at/">
           <img class="center-block" src="./images/webclerks-logo.jpeg" alt="webclerks">
           <p class="center">Webclerks</p>
@@ -193,10 +193,16 @@
       </div>
       </li>
       <li>
-      <div class="col s12 m3">
+      <div class="col s12 m4">
         <a class="partner-logo" href="https://reactiveconf.com/">
           <img class="center-block" src="./images/reactive-conf-logo.jpg" alt="reactive conf">
         <p class="center">ReactiveConf</p>
+        </a>
+      </div>
+      <div class="col s12 m4">
+        <a class="partner-logo" href="https://101.at/">
+          <img class="center-block" src="./images/101-logo.png" alt="101 coding und design">
+        <p class="center">101: Coding und Design</p>
         </a>
       </div>
     </li>


### PR DESCRIPTION
At first I experimented with having the 101 logo in front of a white square, so it would fit the section, but I realized that it looks better if the logo stays with the transparent background.

If you have any better ideas just tell me and I can change it and push again.