### PR TITLE
Add DevelopersRising segment to 'About' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,11 @@
       <div class="row">
         <div id="about" class="col l6 s12">
           <h5 class="white-text">About</h5>
-          <p class="grey-text text-lighten-4">This is one of the local groups of the <a href="https://www.freecodecamp.org/" class="teal-text text-darken-4">FreeCodeCamp</a>            platform.</p>
+          <p class="grey-text text-lighten-4">
+            This is one of the local groups of the <a href="https://www.freecodecamp.org/" class="teal-text text-darken-4">FreeCodeCamp</a> platform.
+            It is organized by "DevelopersRising - Verein zur Förderung von ProgrammiererInnen", an official organization with the goal of supporting
+            newcomers and experienced developers alike.
+          </p>
           <br/>
           <h6 class="black-text">Currently organized by: </h6>
           <ul>


### PR DESCRIPTION
The time for me to contribute has finally come (:P). Hope you're happy with the little description i wrote. I added information on the DevelopersRising Verein to the *About* section instead of creating a new one because otherwise it would have become a bit cluttered. See [#35](https://github.com/FCCVienna/FCCVienna.github.io/issues/35) for more information.