### PR TITLE
Fix footer typo and give credit to the contributors in 'built by'

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,8 +300,11 @@
         </div>
         <div class="footer-copyright">
           <div class="container center">
-            <p class="white-text">© 2017 Copyright FCCVienna.</p>
-            <a href="http://www.createdd.com/" class="teal-text text-darken-4">Build by Daniel Deutsch</a>
+            <p class="white-text">© 2017 Copyright FCCVienna</p>
+            <p class="teal-text text-darken-4">
+              Built by <a href="http://createdd.com/" class="teal-text text-darken-4">Daniel Deutsch</a> and a bunch
+              of enthusiastic contributors on <a href="https://github.com/FCCVienna/FCCVienna.github.io" class="teal-text text-darken-4">GitHub</a>.
+            </p>
           </div>
           </div>
   </footer>


### PR DESCRIPTION
PR contains a fix for the wrong tense being used in the footer. I also thought it would be better to give credit to the contributors while still keeping @DDCreationStudios mentioned separately since he initiated the project. Clicking on "Daniel Deutsch" now reveals his website and clicking on "GitHub" leads to this repository which is not mentioned anywhere else on the page.